### PR TITLE
fixed single line entry cut off

### DIFF
--- a/mylog.sh
+++ b/mylog.sh
@@ -100,11 +100,7 @@ shift $((OPTIND-1))
 [ "${1:-}" = "--" ] && shift
 
 if [ "$#" -ne 0 ]; then
-	for var in "$@"
-	do
-    		text+="$var "
-	done
-	quickEntry "$text"
+	quickEntry "$*"
 else
 	newEntry
 fi

--- a/mylog.sh
+++ b/mylog.sh
@@ -100,7 +100,11 @@ shift $((OPTIND-1))
 [ "${1:-}" = "--" ] && shift
 
 if [ "$#" -ne 0 ]; then
-	quickEntry "$@"
+	for var in "$@"
+	do
+    		text+="$var "
+	done
+	quickEntry "$text"
 else
 	newEntry
 fi


### PR DESCRIPTION
only the first parameter was used. Log entries got cutoff because of a whitespace. Now all the parameters get concatenated.